### PR TITLE
Fix Bundles directory location in README (installation instructions)

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -19,8 +19,8 @@ h3. TODO:
 h2. Installation
 
 <pre>
-mkdir -p ~/Library/Application\ Support/TextMate/Bundles/
-cd ~/Library/Application\ Support/TextMate/Bundles
+mkdir -p ~/Library/Application\ Support/TextMate/Managed/Bundles/
+cd ~/Library/Application\ Support/TextMate/Managed/Bundles
 git clone git://github.com/jessmartin/taskpaper-tmbundle.git Taskpaper.tmbundle
 </pre>
 


### PR DESCRIPTION
In TextMate 2, Bundles directory location was changed from `Bundles` to `Managed/Bundles`.

See also MarioRicalde/SCSS.tmbundle#61, for a similar issue.
